### PR TITLE
[#14] Set up github templates and workflow skills

### DIFF
--- a/.agents/skills/rubedo-create-issue/SKILL.md
+++ b/.agents/skills/rubedo-create-issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: rubedo-create-issue
+description: Create a GitHub Issue in the Rubedo project. Use when user wants to create an issue, task, or spike.
+---
+
+You are creating a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Read conventions
+Read `docs/conventions/workflow.md` from the repository root. Focus on the `## Issues` section.
+
+## Step 2 — Determine issue type
+Ask the user: "Task or Spike?" — nothing else.
+
+## Step 3 — Propose a title
+Propose a title following the conventions from `workflow.md` (`## Issues`).
+Ask for confirmation or correction.
+
+## Step 4 — Collect remaining details
+Ask for any information missing to fill the template:
+- For Task: Description, Acceptance Criteria, QA Notes
+- For Spike: Hypothesis / Question, Approach, Definition of Done
+
+Propose sensible defaults where possible. Ask one question at a time.
+
+## Step 5 — Create the issue
+Use `mcp__github__create_issue` with:
+- `owner`: read from git remote
+- `repo`: read from git remote
+- `title`: confirmed title from Step 3
+- `body`: filled template in English (structure from workflow.md)
+- `assignees`: ["kemotable"]
+- `labels`: ["feature"] for Task, ["spike"] for Spike
+
+Confirm the full issue body with the user before submitting.

--- a/.agents/skills/rubedo-create-pr/SKILL.md
+++ b/.agents/skills/rubedo-create-pr/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: rubedo-create-pr
+description: Create a GitHub Pull Request in the Rubedo project. Use when user wants to open a PR or merge their branch.
+---
+
+You are creating a GitHub Pull Request for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Read conventions
+Read `docs/conventions/workflow.md` from the repository root. Focus on the `## Pull requests` section.
+
+## Step 2 — Determine current branch and issue number
+Run `git branch --show-current` in the repository root.
+Extract the issue number from the branch name — expected format: `{issue-number}-{description}` (e.g. `12-add-transaction-model` → issue #12).
+If the issue number cannot be determined unambiguously, ask the user.
+
+## Step 3 — Fetch issue title
+Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.
+
+## Step 4 — Collect PR body details
+Ask the user for:
+- Summary: what was implemented and why
+- Scope: what is included, what was explicitly left out (if non-obvious)
+- Confirmation that QA Notes from the issue have been verified
+
+Propose sensible defaults where possible. Ask one question at a time.
+
+## Step 5 — Create the PR
+Use `mcp__github__create_pull_request` with:
+- `owner`: read from git remote
+- `repo`: read from git remote
+- `title`: issue title from Step 3
+- `head`: current branch from Step 2
+- `base`: "main"
+- `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
+
+Confirm the full PR body with the user before submitting.

--- a/.claude/skills/rubedo-create-issue/SKILL.md
+++ b/.claude/skills/rubedo-create-issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: rubedo-create-issue
+description: Create a GitHub Issue in the Rubedo project. Use when user wants to create an issue, task, or spike.
+---
+
+You are creating a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Read conventions
+Read `docs/conventions/workflow.md` from the repository root. Focus on the `## Issues` section.
+
+## Step 2 — Determine issue type
+Ask the user: "Task or Spike?" — nothing else.
+
+## Step 3 — Propose a title
+Propose a title following the conventions from `workflow.md` (`## Issues`).
+Ask for confirmation or correction.
+
+## Step 4 — Collect remaining details
+Ask for any information missing to fill the template:
+- For Task: Description, Acceptance Criteria, QA Notes
+- For Spike: Hypothesis / Question, Approach, Definition of Done
+
+Propose sensible defaults where possible. Ask one question at a time.
+
+## Step 5 — Create the issue
+Use `mcp__github__create_issue` with:
+- `owner`: read from git remote
+- `repo`: read from git remote
+- `title`: confirmed title from Step 3
+- `body`: filled template in English (structure from workflow.md)
+- `assignees`: ["kemotable"]
+- `labels`: ["feature"] for Task, ["spike"] for Spike
+
+Confirm the full issue body with the user before submitting.

--- a/.claude/skills/rubedo-create-pr/SKILL.md
+++ b/.claude/skills/rubedo-create-pr/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: rubedo-create-pr
+description: Create a GitHub Pull Request in the Rubedo project. Use when user wants to open a PR or merge their branch.
+---
+
+You are creating a GitHub Pull Request for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Read conventions
+Read `docs/conventions/workflow.md` from the repository root. Focus on the `## Pull requests` section.
+
+## Step 2 — Determine current branch and issue number
+Run `git branch --show-current` in the repository root.
+Extract the issue number from the branch name — expected format: `{issue-number}-{description}` (e.g. `12-add-transaction-model` → issue #12).
+If the issue number cannot be determined unambiguously, ask the user.
+
+## Step 3 — Fetch issue title
+Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.
+
+## Step 4 — Collect PR body details
+Ask the user for:
+- Summary: what was implemented and why
+- Scope: what is included, what was explicitly left out (if non-obvious)
+- Confirmation that QA Notes from the issue have been verified
+
+Propose sensible defaults where possible. Ask one question at a time.
+
+## Step 5 — Create the PR
+Use `mcp__github__create_pull_request` with:
+- `owner`: read from git remote
+- `repo`: read from git remote
+- `title`: issue title from Step 3
+- `head`: current branch from Step 2
+- `base`: "main"
+- `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
+
+Confirm the full PR body with the user before submitting.

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,17 @@
+---
+name: Spike
+about: Time-boxed research with a defined question and output
+labels: spike
+assignees: kemotable
+---
+
+## Hypothesis / Question
+[What we want to find out and why]
+
+## Approach
+[How we plan to investigate]
+
+## Definition of Done
+- [ ] Question from "Hypothesis" has been answered
+- [ ] Output documented (ADR / inbox / issue comment)
+- [ ] Follow-up Issue/s extracted (if applicable)

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Task
+about: Standard development task — feature, chore, fix
+labels: feature
+assignees: kemotable
+---
+
+## Description
+[What and why]
+
+## Acceptance Criteria
+- [ ] ...
+
+## QA Notes
+[How to verify this is done]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+Closes #
+
+## Summary
+[What was implemented and why]
+
+## Scope
+[What is included. What was explicitly left out, if non-obvious.]
+
+## Verification
+- [ ] Verified according to Issue QA Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+Entry point for AI agents and future-self working in this repository.
+
+## Project character
+
+Rubedo is a long-horizon (6–12 months+) personal finance application built
+iteratively, without rush. It is simultaneously a real-use product and a
+portfolio-grade exercise in domain modelling and pragmatic event-driven
+architecture. Trade-offs are made explicit in ADRs, not hidden. Features and
+infrastructure are added when a real need appears, not preventively.
+
+## Non-goals
+
+- Not a SaaS, not a multi-tenant product.
+- Not optimised for fastest delivery.
+- Not "best practices for the sake of best practices".
+
+## Where things live
+
+- `docs/adr/` — architectural decisions. Read the ones touching the area you're
+  working in. Each ADR has a `Status` field (Draft / Proposed / Accepted /
+  Superseded / Deferred).
+- `docs/conventions/` — rules that apply at every step of work.
+  - `domain.md` — how the domain is modelled (money, time, locale, naming).
+  - `code.md` — Ruby/Rails patterns, structure, testing.
+  - `workflow.md` — Git, PR, branch, release.
+- `docs/inbox.md` — raw thought capture. Do **not** act on entries here unless
+  explicitly asked. They are unrefined and may be wrong.
+- `README.md` — public-facing overview; not normally needed during work.
+- GitHub **Issues** — concrete tasks.
+- GitHub **Milestones** — roadmap and current scope.
+- GitHub **Releases** — version history / "what is done".
+
+`docs/CONTEXT.md` (domain glossary) and `docs/ops/` (runbooks) will appear when
+the project reaches the relevant milestones; they don't exist yet by design.
+
+## How decisions get made here
+
+- A choice that is **hard to reverse**, **surprising without context**, **and
+  the result of a real trade-off** → propose an ADR (Status: Draft) before
+  implementing.
+- A rule that applies at every step (naming, money, time, Git workflow) →
+  propose an addition to the relevant `docs/conventions/*.md`.
+- A throwaway thought worth keeping → I'll add it to `docs/inbox.md` myself;
+  don't act on it.

--- a/docs/conventions/workflow.md
+++ b/docs/conventions/workflow.md
@@ -10,13 +10,38 @@ contributing changes.
 - Feature branches are derived from a GitHub Issue and use the issue-derived
   branch name.
 
+## Issues
+
+Two issue types exist in this repository, each with its own GitHub template:
+
+**Task** — a standard development unit (feature, chore, fix, infra, docs).
+Structure: `Description`, `Acceptance Criteria`, `QA Notes`.
+
+**Spike** — a time-boxed research unit with a defined question and output.
+Structure: `Hypothesis / Question`, `Approach`, `Definition of Done`.
+A Spike always ends with either a conclusion documented in an ADR or inbox
+entry, or one or more follow-up Task issues extracted from it.
+
+Issue titles must be concise and imperative: maximum 5 words, no articles (a, the).
+Examples: "Add transaction model", "Spike: evaluate background jobs".
+GitHub derives the branch name from the title — keep it short.
+
+All issues are assigned to `kemotable` and labelled on creation.
+Available labels: `feature`, `bug`, `chore`, `infra`, `docs`, `spike`.
+Milestone is assigned manually after issue creation.
+
+Epics are not used. Milestones serve as the grouping mechanism for related
+issues.
+
 ## Pull requests
 
 - No direct commits to `main`. Every change goes through a PR.
 - A PR must reference its issue with `Closes #X` (auto-close) or `Refs #X`
   (link only).
-- A PR description must describe: context, scope, reasoning, and
-  architectural impact (if any).
+- The first line of every PR description is `Closes #X` or `Refs #X`.
+- A PR description contains: `Summary` (what and why), `Scope` (what is
+  included and what was explicitly left out), `Verification` (confirmed
+  against Issue QA Notes).
 - The PR template lives at `.github/pull_request_template.md`.
 - History stays linear: prefer `squash` or `rebase` merges; merge commits
   disabled in the repository settings.


### PR DESCRIPTION
Closes #14

## Summary
Introduces two GitHub Issue templates (Task, Spike), updates the PR template, updates workflow conventions, and adds two Claude/Codex skills for creating issues and PRs consistently.

## Scope
Included: Issue templates, PR template, workflow.md, rubedo-create-issue and rubedo-create-pr skills in both .claude/skills/ and .agents/skills/. 
Not included: GitHub Actions for milestone auto-assignment (accepted as manual), GitHub MCP configuration (separate concern).

## Verification
- [x] Verified according to Issue QA Notes