### PR TITLE
Improve agent foundation

### DIFF
--- a/.agents/skills/rubedo-create-issue/SKILL.md
+++ b/.agents/skills/rubedo-create-issue/SKILL.md
@@ -29,7 +29,19 @@ Ask for any information missing to fill the template:
 - For Task: Description, Acceptance Criteria, QA Notes
 - For Spike: Hypothesis / Question, Approach, Definition of Done
 
-Propose sensible defaults where possible. Ask one question at a time.
+Propose sensible defaults where possible. Ask one question at a time only
+until you have enough context to draft the whole issue.
+
+Once you have enough context, stop asking section-by-section approval
+questions and generate the complete issue proposal in one response:
+
+- issue type
+- title
+- label
+- assignee
+- full issue body
+
+Ask the user to approve or correct the complete proposal.
 
 ## Step 6 — Create the issue
 Use `mcp__github__create_issue` with:
@@ -40,4 +52,4 @@ Use `mcp__github__create_issue` with:
 - `assignees`: ["kemotable"]
 - `labels`: confirmed task label for Task, `spike` for Spike
 
-Confirm the full issue body with the user before submitting.
+Confirm the complete issue proposal with the user before submitting.

--- a/.agents/skills/rubedo-create-issue/SKILL.md
+++ b/.agents/skills/rubedo-create-issue/SKILL.md
@@ -15,20 +15,29 @@ Ask the user: "Task or Spike?" — nothing else.
 Propose a title following the conventions from `workflow.md` (`## Issues`).
 Ask for confirmation or correction.
 
-## Step 4 — Collect remaining details
+## Step 4 — Suggest the issue label
+If the issue type is `Task`, suggest the most appropriate single label from:
+`feature`, `bug`, `chore`, `infra`, `docs`.
+
+Base the suggestion on the issue context gathered from the user so far.
+Ask the user to confirm or correct the suggested label before continuing.
+
+If the issue type is `Spike`, use the label `spike` and do not ask for a label.
+
+## Step 5 — Collect remaining details
 Ask for any information missing to fill the template:
 - For Task: Description, Acceptance Criteria, QA Notes
 - For Spike: Hypothesis / Question, Approach, Definition of Done
 
 Propose sensible defaults where possible. Ask one question at a time.
 
-## Step 5 — Create the issue
+## Step 6 — Create the issue
 Use `mcp__github__create_issue` with:
 - `owner`: read from git remote
 - `repo`: read from git remote
 - `title`: confirmed title from Step 3
 - `body`: filled template in English (structure from workflow.md)
 - `assignees`: ["kemotable"]
-- `labels`: ["feature"] for Task, ["spike"] for Spike
+- `labels`: confirmed task label for Task, `spike` for Spike
 
 Confirm the full issue body with the user before submitting.

--- a/.agents/skills/rubedo-create-pr/SKILL.md
+++ b/.agents/skills/rubedo-create-pr/SKILL.md
@@ -10,8 +10,10 @@ Read `docs/conventions/workflow.md` from the repository root. Focus on the `## P
 
 ## Step 2 — Determine current branch and issue number
 Run `git branch --show-current` in the repository root.
-Extract the issue number from the branch name — expected format: `{issue-number}-{description}` (e.g. `12-add-transaction-model` → issue #12).
-If the issue number cannot be determined unambiguously, ask the user.
+If the branch name starts with an issue number followed by `-`, extract it
+(e.g. `12-add-transaction-model` → issue #12).
+If the issue number cannot be determined unambiguously from the branch name,
+ask the user instead of guessing.
 
 ## Step 3 — Fetch issue title
 Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.

--- a/.agents/skills/rubedo-create-pr/SKILL.md
+++ b/.agents/skills/rubedo-create-pr/SKILL.md
@@ -24,7 +24,24 @@ Ask the user for:
 - Scope: what is included, what was explicitly left out (if non-obvious)
 - Confirmation that QA Notes from the issue have been verified
 
-Propose sensible defaults where possible. Ask one question at a time.
+Propose sensible defaults where possible. Ask one question at a time only
+until you have enough context to draft the whole PR.
+
+Once you have enough context, stop asking section-by-section approval
+questions and generate the complete PR proposal in one response:
+
+- title
+- base branch
+- head branch
+- full PR body
+
+Format `Summary` and `Scope` for readability:
+
+- Use bullet lists when there is more than one distinct point
+- Prefer 2-5 short bullets over one long paragraph
+- Use a short paragraph only when the content is genuinely one point
+
+Ask the user to approve or correct the complete proposal.
 
 ## Step 5 — Create the PR
 Use `mcp__github__create_pull_request` with:
@@ -35,4 +52,4 @@ Use `mcp__github__create_pull_request` with:
 - `base`: "main"
 - `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
 
-Confirm the full PR body with the user before submitting.
+Confirm the complete PR proposal with the user before submitting.

--- a/.agents/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.agents/skills/setup-matt-pocock-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-matt-pocock-skills
-description: Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker (GitHub or local markdown), triage label vocabulary, and domain doc layout. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing context about the issue tracker, triage labels, or domain docs.
+description: Sets up an `## Agent skills` block in AGENTS.md/CLAUDE.md and `docs/agents/` so the engineering skills know this repo's issue tracker, domain doc layout, and current agent-entrypoint strategy. Run before first use of `to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, or `zoom-out` — or if those skills appear to be missing repo-specific guidance.
 disable-model-invocation: true
 ---
 
@@ -9,8 +9,8 @@ disable-model-invocation: true
 Scaffold the per-repo configuration that the engineering skills assume:
 
 - **Issue tracker** — where issues live (GitHub by default; local markdown is also supported out of the box)
-- **Triage labels** — the strings used for the five canonical triage roles
 - **Domain docs** — where `CONTEXT.md` and ADRs live, and the consumer rules for reading them
+- **Agent entrypoints** — whether one file is canonical yet, or whether the repo is still intentionally supporting multiple agent entrypoints
 
 This is a prompt-driven skill, not a deterministic script. Explore, present what you found, confirm with the user, then write.
 
@@ -44,21 +44,7 @@ Default posture: these skills were designed for GitHub. If a `git remote` points
 - **Local markdown** — issues live as files under `.scratch/<feature>/` in this repo (good for solo projects or repos without a remote)
 - **Other** (Jira, Linear, etc.) — ask the user to describe the workflow in one paragraph; the skill will record it as freeform prose
 
-**Section B — Triage label vocabulary.**
-
-> Explainer: When the `triage` skill processes an incoming issue, it moves it through a state machine — needs evaluation, waiting on reporter, ready for an AFK agent to pick up, ready for a human, or won't fix. To do that, it needs to apply labels (or the equivalent in your issue tracker) that match strings *you've actually configured*. If your repo already uses different label names (e.g. `bug:triage` instead of `needs-triage`), map them here so the skill applies the right ones instead of creating duplicates.
-
-The five canonical roles:
-
-- `needs-triage` — maintainer needs to evaluate
-- `needs-info` — waiting on reporter
-- `ready-for-agent` — fully specified, AFK-ready (an agent can pick it up with no human context)
-- `ready-for-human` — needs human implementation
-- `wontfix` — will not be actioned
-
-Default: each role's string equals its name. Ask the user if they want to override any. If their issue tracker has no existing labels, the defaults are fine.
-
-**Section C — Domain docs.**
+**Section B — Domain docs.**
 
 > Explainer: Some skills (`improve-codebase-architecture`, `diagnose`, `tdd`) read a `CONTEXT.md` file to learn the project's domain language, and `docs/adr/` for past architectural decisions. They need to know whether the repo has one global context or multiple (e.g. a monorepo with separate frontend/backend contexts) so they look in the right place.
 
@@ -67,12 +53,21 @@ Confirm the layout:
 - **Single-context** — one `CONTEXT.md` + `docs/adr/` at the repo root. Most repos are this.
 - **Multi-context** — `CONTEXT-MAP.md` at the root pointing to per-context `CONTEXT.md` files (typically a monorepo).
 
+**Section C — Agent entrypoints.**
+
+> Explainer: Some repos keep one canonical agent entrypoint file. Others are temporarily testing multiple agents and want both entrypoint files to stay aligned while shared guidance moves into `docs/agents/`. The skills need to know which posture applies so they do not accidentally create or privilege the wrong file.
+
+Confirm the repo's current rule:
+
+- **Canonical file** — one of `AGENTS.md` or `CLAUDE.md` is authoritative.
+- **Dual-entrypoint trial** — both files stay aligned at a high level, with shared durable guidance moved into `docs/agents/`.
+
 ### 3. Confirm and edit
 
 Show the user a draft of:
 
-- The `## Agent skills` block to add to whichever of `CLAUDE.md` / `AGENTS.md` is being edited (see step 4 for selection rules)
-- The contents of `docs/agents/issue-tracker.md`, `docs/agents/triage-labels.md`, `docs/agents/domain.md`
+- The `## Agent skills` block to add to the repo entrypoint file or files
+- The contents of `docs/agents/issue-tracker.md`, `docs/agents/domain.md`, `docs/agents/agent-files.md`
 
 Let them edit before writing.
 
@@ -80,11 +75,12 @@ Let them edit before writing.
 
 **Pick the file to edit:**
 
-- If `CLAUDE.md` exists, edit it.
+- If the repo is in a dual-entrypoint trial and both `CLAUDE.md` and `AGENTS.md` exist, update both with the same short navigational block.
+- Else if `CLAUDE.md` exists, edit it.
 - Else if `AGENTS.md` exists, edit it.
 - If neither exists, ask the user which one to create — don't pick for them.
 
-Never create `AGENTS.md` when `CLAUDE.md` already exists (or vice versa) — always edit the one that's already there.
+Never create a second entrypoint file unless the user explicitly wants a dual-entrypoint setup.
 
 If an `## Agent skills` block already exists in the chosen file, update its contents in-place rather than appending a duplicate. Don't overwrite user edits to the surrounding sections.
 
@@ -93,26 +89,21 @@ The block:
 ```markdown
 ## Agent skills
 
-### Issue tracker
+Repo-specific agent guidance lives in `docs/agents/`.
 
-[one-line summary of where issues are tracked]. See `docs/agents/issue-tracker.md`.
-
-### Triage labels
-
-[one-line summary of the label vocabulary]. See `docs/agents/triage-labels.md`.
-
-### Domain docs
-
-[one-line summary of layout — "single-context" or "multi-context"]. See `docs/agents/domain.md`.
+- Issue tracker workflow: see `docs/agents/issue-tracker.md`
+- Domain-document entrypoints: see `docs/agents/domain.md`
+- Agent-file handling: see `docs/agents/agent-files.md`
 ```
 
-Then write the three docs files using the seed templates in this skill folder as a starting point:
+Then write the docs files using the seed templates in this skill folder as a starting point:
 
 - [issue-tracker-github.md](./issue-tracker-github.md) — GitHub issue tracker
 - [issue-tracker-gitlab.md](./issue-tracker-gitlab.md) — GitLab issue tracker
 - [issue-tracker-local.md](./issue-tracker-local.md) — local-markdown issue tracker
-- [triage-labels.md](./triage-labels.md) — label mapping
 - [domain.md](./domain.md) — domain doc consumer rules + layout
+
+Write `docs/agents/agent-files.md` from scratch unless the repo already has an equivalent file.
 
 For "other" issue trackers, write `docs/agents/issue-tracker.md` from scratch using the user's description.
 

--- a/.claude/skills/rubedo-create-issue/SKILL.md
+++ b/.claude/skills/rubedo-create-issue/SKILL.md
@@ -29,7 +29,19 @@ Ask for any information missing to fill the template:
 - For Task: Description, Acceptance Criteria, QA Notes
 - For Spike: Hypothesis / Question, Approach, Definition of Done
 
-Propose sensible defaults where possible. Ask one question at a time.
+Propose sensible defaults where possible. Ask one question at a time only
+until you have enough context to draft the whole issue.
+
+Once you have enough context, stop asking section-by-section approval
+questions and generate the complete issue proposal in one response:
+
+- issue type
+- title
+- label
+- assignee
+- full issue body
+
+Ask the user to approve or correct the complete proposal.
 
 ## Step 6 — Create the issue
 Use `mcp__github__create_issue` with:
@@ -40,4 +52,4 @@ Use `mcp__github__create_issue` with:
 - `assignees`: ["kemotable"]
 - `labels`: confirmed task label for Task, `spike` for Spike
 
-Confirm the full issue body with the user before submitting.
+Confirm the complete issue proposal with the user before submitting.

--- a/.claude/skills/rubedo-create-issue/SKILL.md
+++ b/.claude/skills/rubedo-create-issue/SKILL.md
@@ -15,20 +15,29 @@ Ask the user: "Task or Spike?" — nothing else.
 Propose a title following the conventions from `workflow.md` (`## Issues`).
 Ask for confirmation or correction.
 
-## Step 4 — Collect remaining details
+## Step 4 — Suggest the issue label
+If the issue type is `Task`, suggest the most appropriate single label from:
+`feature`, `bug`, `chore`, `infra`, `docs`.
+
+Base the suggestion on the issue context gathered from the user so far.
+Ask the user to confirm or correct the suggested label before continuing.
+
+If the issue type is `Spike`, use the label `spike` and do not ask for a label.
+
+## Step 5 — Collect remaining details
 Ask for any information missing to fill the template:
 - For Task: Description, Acceptance Criteria, QA Notes
 - For Spike: Hypothesis / Question, Approach, Definition of Done
 
 Propose sensible defaults where possible. Ask one question at a time.
 
-## Step 5 — Create the issue
+## Step 6 — Create the issue
 Use `mcp__github__create_issue` with:
 - `owner`: read from git remote
 - `repo`: read from git remote
 - `title`: confirmed title from Step 3
 - `body`: filled template in English (structure from workflow.md)
 - `assignees`: ["kemotable"]
-- `labels`: ["feature"] for Task, ["spike"] for Spike
+- `labels`: confirmed task label for Task, `spike` for Spike
 
 Confirm the full issue body with the user before submitting.

--- a/.claude/skills/rubedo-create-pr/SKILL.md
+++ b/.claude/skills/rubedo-create-pr/SKILL.md
@@ -10,8 +10,10 @@ Read `docs/conventions/workflow.md` from the repository root. Focus on the `## P
 
 ## Step 2 — Determine current branch and issue number
 Run `git branch --show-current` in the repository root.
-Extract the issue number from the branch name — expected format: `{issue-number}-{description}` (e.g. `12-add-transaction-model` → issue #12).
-If the issue number cannot be determined unambiguously, ask the user.
+If the branch name starts with an issue number followed by `-`, extract it
+(e.g. `12-add-transaction-model` → issue #12).
+If the issue number cannot be determined unambiguously from the branch name,
+ask the user instead of guessing.
 
 ## Step 3 — Fetch issue title
 Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.

--- a/.claude/skills/rubedo-create-pr/SKILL.md
+++ b/.claude/skills/rubedo-create-pr/SKILL.md
@@ -24,7 +24,24 @@ Ask the user for:
 - Scope: what is included, what was explicitly left out (if non-obvious)
 - Confirmation that QA Notes from the issue have been verified
 
-Propose sensible defaults where possible. Ask one question at a time.
+Propose sensible defaults where possible. Ask one question at a time only
+until you have enough context to draft the whole PR.
+
+Once you have enough context, stop asking section-by-section approval
+questions and generate the complete PR proposal in one response:
+
+- title
+- base branch
+- head branch
+- full PR body
+
+Format `Summary` and `Scope` for readability:
+
+- Use bullet lists when there is more than one distinct point
+- Prefer 2-5 short bullets over one long paragraph
+- Use a short paragraph only when the content is genuinely one point
+
+Ask the user to approve or correct the complete proposal.
 
 ## Step 5 — Create the PR
 Use `mcp__github__create_pull_request` with:
@@ -35,4 +52,4 @@ Use `mcp__github__create_pull_request` with:
 - `base`: "main"
 - `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
 
-Confirm the full PR body with the user before submitting.
+Confirm the complete PR proposal with the user before submitting.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,12 @@
 Closes #
 
 ## Summary
-[What was implemented and why]
+- [What was implemented]
+- [Why it was implemented]
 
 ## Scope
-[What is included. What was explicitly left out, if non-obvious.]
+- [What is included]
+- [What was explicitly left out, if non-obvious]
 
 ## Verification
 - [ ] Verified according to Issue QA Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,11 @@ the project reaches the relevant milestones; they don't exist yet by design.
   propose an addition to the relevant `docs/conventions/*.md`.
 - A throwaway thought worth keeping → I'll add it to `docs/inbox.md` myself;
   don't act on it.
+
+## Agent skills
+
+Repo-specific guidance for agents lives in `docs/agents/`.
+
+- Issue tracker workflow: see `docs/agents/issue-tracker.md`
+- Domain docs: see `docs/agents/domain.md`
+- Dual-agent entry points: see `docs/agents/agent-files.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,11 @@ the project reaches the relevant milestones; they don't exist yet by design.
   propose an addition to the relevant `docs/conventions/*.md`.
 - A throwaway thought worth keeping → I'll add it to `docs/inbox.md` myself;
   don't act on it.
+
+## Agent skills
+
+Repo-specific guidance for agents lives in `docs/agents/`.
+
+- Issue tracker workflow: see `docs/agents/issue-tracker.md`
+- Domain docs: see `docs/agents/domain.md`
+- Dual-agent entry points: see `docs/agents/agent-files.md`

--- a/docs/agents/agent-files.md
+++ b/docs/agents/agent-files.md
@@ -1,0 +1,16 @@
+# Agent entry points
+
+Rubedo is currently being tested with both Codex and Claude.
+
+For now, `AGENTS.md` and `CLAUDE.md` are intentionally kept aligned at a
+high level so each agent starts from the same project context.
+
+## Current rule
+
+- Do not treat either file as canonical yet.
+- When proposing repo-wide agent guidance, prefer moving stable details into
+  shared files under `docs/agents/` or `docs/conventions/`.
+- Keep the entry point files short and mostly navigational to reduce drift.
+
+Once the dual-agent trial ends, the repository may choose a canonical
+entry point file or automate mirroring between the two.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,13 @@
+# Agent domain docs
+
+When working in Rubedo, read the repository guidance in this order:
+
+1. `AGENTS.md` or `CLAUDE.md` for the project character and repo entry points
+2. `docs/conventions/domain.md` for domain and data-handling rules
+3. `docs/conventions/code.md` for binding code conventions
+4. `docs/conventions/workflow.md` for issue, PR, and release-process rules
+5. `docs/adr/` entries that touch the area being changed
+
+`docs/CONTEXT.md` does not exist yet by design. Until it appears, agents
+should treat `docs/conventions/domain.md` plus accepted ADRs as the current
+domain-language source.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,29 @@
+# Agent issue tracker
+
+Rubedo uses GitHub Issues as the source of truth for planned work.
+
+## Issue types
+
+- `Task` is the standard unit for implementation work.
+- `Spike` is a time-boxed research unit that should end in a conclusion,
+  follow-up tasks, or both.
+
+Agents should follow the issue structures defined in
+`docs/conventions/workflow.md` and the GitHub templates in
+`.github/ISSUE_TEMPLATE/`.
+
+## Labels
+
+When creating a `Task`, suggest one label based on the issue context and ask
+for confirmation before submitting:
+
+- `feature`
+- `bug`
+- `chore`
+- `infra`
+- `docs`
+
+When creating a `Spike`, use `spike`.
+
+All issues are assigned to `kemotable`.
+Milestones are assigned manually after issue creation.

--- a/docs/conventions/workflow.md
+++ b/docs/conventions/workflow.md
@@ -48,9 +48,8 @@ issues.
 
 ## Releases
 
-See ADR-0004 (currently Draft) for the release strategy. In short: SemVer
-starting at `v0.1.0`, releases cut via GitHub UI, production deploys tied
-to versioned releases.
+Release conventions are not finalised yet.
+To be defined once ADR-0004 moves beyond Draft.
 
 ## Decisions that change these conventions
 


### PR DESCRIPTION
Closes #16

## Summary
- Added lightweight `docs/agents/` guidance for issue tracking, domain-document entry points, and dual-agent entry-point handling
- Updated `AGENTS.md` and `CLAUDE.md` to point agents at shared repo-specific guidance instead of duplicating more instructions
- Adjusted helper skills so issue creation suggests a label from context and PR creation no longer assumes one rigid branch-name format
- Aligned the setup skill and workflow docs with the current foundation state, including the draft status of release conventions

## Scope
- Included shared agent guidance under `docs/agents/`
- Included updates to agent entrypoint docs and issue/PR helper skills
- Included a small editorial pass on wording and naming for consistency
- Explicitly left out any decision on a canonical agent file
- Explicitly left out broader expansion of project conventions beyond the current foundation needs

## Verification
- [x] Verified according to Issue QA Notes