### PR TITLE
Switch PR and issue workflow to gh CLI

### DIFF
--- a/.agents/skills/rubedo-create-commit/SKILL.md
+++ b/.agents/skills/rubedo-create-commit/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rubedo-create-commit
+description: Stage all changed files and create a git commit in the Rubedo project. Use when user wants to commit work in progress.
+---
+
+You are creating a git commit for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Determine issue number
+Derive the issue number from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Show pending changes
+Run:
+
+```bash
+git status && git diff --stat
+```
+
+Present the output so the user can see what will be committed.
+
+## Step 3 — Propose commit message
+Based on the changes from Step 2, propose a commit message. Do not ask the user to provide one.
+
+The message must be:
+- Short and clear (one line, no extended description)
+- Written in imperative mood (e.g. "Add gh CLI commands", not "Added")
+
+Ask the user to confirm or correct the proposed message.
+
+## Step 4 — Confirm
+Show the user the full commit command before executing:
+
+```
+git add -A && git commit -m "[#ISSUE_NUMBER] MESSAGE"
+```
+
+Ask for confirmation.
+
+## Step 5 — Commit
+Run:
+
+```bash
+git add -A && git commit -m "[#ISSUE_NUMBER] MESSAGE"
+```
+
+Replace `ISSUE_NUMBER` and `MESSAGE` with the values from Steps 1 and 3.
+
+**Do NOT run `git push`.**

--- a/.agents/skills/rubedo-create-issue/SKILL.md
+++ b/.agents/skills/rubedo-create-issue/SKILL.md
@@ -43,13 +43,22 @@ questions and generate the complete issue proposal in one response:
 
 Ask the user to approve or correct the complete proposal.
 
-## Step 6 — Create the issue
-Use `mcp__github__create_issue` with:
-- `owner`: read from git remote
-- `repo`: read from git remote
-- `title`: confirmed title from Step 3
-- `body`: filled template in English (structure from workflow.md)
-- `assignees`: ["kemotable"]
-- `labels`: confirmed task label for Task, `spike` for Spike
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
 
-Confirm the complete issue proposal with the user before submitting.
+## Step 6 — Create the issue
+Run:
+
+```bash
+gh issue create \
+  --title "TITLE" \
+  --body "BODY" \
+  --assignee kemotable \
+  --label LABEL
+```
+
+Replace `TITLE`, `BODY`, and `LABEL` with the confirmed values.
+`BODY` must use the filled template in English (structure from workflow.md).
+
+Confirm the complete issue proposal with the user before running the command.

--- a/.agents/skills/rubedo-create-pr/SKILL.md
+++ b/.agents/skills/rubedo-create-pr/SKILL.md
@@ -16,7 +16,13 @@ If the issue number cannot be determined unambiguously from the branch name,
 ask the user instead of guessing.
 
 ## Step 3 — Fetch issue title
-Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER --json title --jq '.title'
+```
+
+Use the returned title as the PR title.
 
 ## Step 4 — Collect PR body details
 Ask the user for:
@@ -43,13 +49,34 @@ Format `Summary` and `Scope` for readability:
 
 Ask the user to approve or correct the complete proposal.
 
-## Step 5 — Create the PR
-Use `mcp__github__create_pull_request` with:
-- `owner`: read from git remote
-- `repo`: read from git remote
-- `title`: issue title from Step 3
-- `head`: current branch from Step 2
-- `base`: "main"
-- `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
 
-Confirm the complete PR proposal with the user before submitting.
+## Step 5 — Create the PR
+Run:
+
+```bash
+gh pr create \
+  --title "TITLE" \
+  --base main \
+  --head BRANCH \
+  --body "$(cat <<'EOF'
+Closes #ISSUE_NUMBER
+
+## Summary
+SUMMARY
+
+## Scope
+SCOPE
+
+## Verification
+VERIFICATION
+EOF
+)"
+```
+
+Replace `TITLE`, `BRANCH`, `ISSUE_NUMBER`, `SUMMARY`, `SCOPE`, and `VERIFICATION`
+with the confirmed values.
+
+Confirm the complete PR proposal with the user before running the command.

--- a/.agents/skills/rubedo-read-issue/SKILL.md
+++ b/.agents/skills/rubedo-read-issue/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: rubedo-read-issue
+description: Read a GitHub Issue in the Rubedo project. Use when user wants to view issue details or when starting work on an issue.
+---
+
+You are reading a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Determine issue number
+If the user provided an issue number explicitly, use it.
+
+Otherwise, derive it from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Fetch the issue
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER
+```
+
+Replace `ISSUE_NUMBER` with the number from Step 1.
+
+The output is context for the current session. Do not repeat it back to the user.

--- a/.agents/skills/rubedo-update-issue/SKILL.md
+++ b/.agents/skills/rubedo-update-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rubedo-update-issue
+description: Update the body of an existing GitHub Issue in the Rubedo project. Use when requirements, Acceptance Criteria, or any other issue content needs to change.
+---
+
+You are updating a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
+
+## Step 1 — Determine issue number
+If the user provided an issue number explicitly, use it.
+
+Otherwise, derive it from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Fetch current issue content
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER --json title,body --jq '{title: .title, body: .body}'
+```
+
+Load the current title and body into context. Do not repeat them back to the user.
+
+## Step 3 — Collect changes
+Ask the user what should change. Apply the requested changes to the body while
+preserving all unaffected sections.
+
+Once you have enough context, present the complete proposed new body to the user
+for approval.
+
+## Step 4 — Update the issue
+Run:
+
+```bash
+gh issue edit ISSUE_NUMBER --body "NEW_BODY"
+```
+
+Replace `ISSUE_NUMBER` with the number from Step 1 and `NEW_BODY` with the
+approved body from Step 3.
+
+Confirm with the user before running the command.

--- a/.claude/skills/rubedo-create-commit/SKILL.md
+++ b/.claude/skills/rubedo-create-commit/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: rubedo-create-commit
+description: Stage all changed files and create a git commit in the Rubedo project. Use when user wants to commit work in progress.
+---
+
+You are creating a git commit for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Determine issue number
+Derive the issue number from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Show pending changes
+Run:
+
+```bash
+git status && git diff --stat
+```
+
+Present the output so the user can see what will be committed.
+
+## Step 3 — Propose commit message
+Based on the changes from Step 2, propose a commit message. Do not ask the user to provide one.
+
+The message must be:
+- Short and clear (one line, no extended description)
+- Written in imperative mood (e.g. "Add gh CLI commands", not "Added")
+
+Ask the user to confirm or correct the proposed message.
+
+## Step 4 — Confirm
+Show the user the full commit command before executing:
+
+```
+git add -A && git commit -m "[#ISSUE_NUMBER] MESSAGE"
+```
+
+Ask for confirmation.
+
+## Step 5 — Commit
+Run:
+
+```bash
+git add -A && git commit -m "[#ISSUE_NUMBER] MESSAGE"
+```
+
+Replace `ISSUE_NUMBER` and `MESSAGE` with the values from Steps 1 and 3.
+
+**Do NOT run `git push`.**

--- a/.claude/skills/rubedo-create-issue/SKILL.md
+++ b/.claude/skills/rubedo-create-issue/SKILL.md
@@ -43,13 +43,22 @@ questions and generate the complete issue proposal in one response:
 
 Ask the user to approve or correct the complete proposal.
 
-## Step 6 — Create the issue
-Use `mcp__github__create_issue` with:
-- `owner`: read from git remote
-- `repo`: read from git remote
-- `title`: confirmed title from Step 3
-- `body`: filled template in English (structure from workflow.md)
-- `assignees`: ["kemotable"]
-- `labels`: confirmed task label for Task, `spike` for Spike
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
 
-Confirm the complete issue proposal with the user before submitting.
+## Step 6 — Create the issue
+Run:
+
+```bash
+gh issue create \
+  --title "TITLE" \
+  --body "BODY" \
+  --assignee kemotable \
+  --label LABEL
+```
+
+Replace `TITLE`, `BODY`, and `LABEL` with the confirmed values.
+`BODY` must use the filled template in English (structure from workflow.md).
+
+Confirm the complete issue proposal with the user before running the command.

--- a/.claude/skills/rubedo-create-pr/SKILL.md
+++ b/.claude/skills/rubedo-create-pr/SKILL.md
@@ -16,7 +16,13 @@ If the issue number cannot be determined unambiguously from the branch name,
 ask the user instead of guessing.
 
 ## Step 3 — Fetch issue title
-Use `mcp__github__get_issue` to fetch the title of the linked issue. Use it as the PR title.
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER --json title --jq '.title'
+```
+
+Use the returned title as the PR title.
 
 ## Step 4 — Collect PR body details
 Ask the user for:
@@ -43,13 +49,34 @@ Format `Summary` and `Scope` for readability:
 
 Ask the user to approve or correct the complete proposal.
 
-## Step 5 — Create the PR
-Use `mcp__github__create_pull_request` with:
-- `owner`: read from git remote
-- `repo`: read from git remote
-- `title`: issue title from Step 3
-- `head`: current branch from Step 2
-- `base`: "main"
-- `body`: filled template in English — first line must be `Closes #{issue_number}`, then Summary, Scope, Verification
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
 
-Confirm the complete PR proposal with the user before submitting.
+## Step 5 — Create the PR
+Run:
+
+```bash
+gh pr create \
+  --title "TITLE" \
+  --base main \
+  --head BRANCH \
+  --body "$(cat <<'EOF'
+Closes #ISSUE_NUMBER
+
+## Summary
+SUMMARY
+
+## Scope
+SCOPE
+
+## Verification
+VERIFICATION
+EOF
+)"
+```
+
+Replace `TITLE`, `BRANCH`, `ISSUE_NUMBER`, `SUMMARY`, `SCOPE`, and `VERIFICATION`
+with the confirmed values.
+
+Confirm the complete PR proposal with the user before running the command.

--- a/.claude/skills/rubedo-read-issue/SKILL.md
+++ b/.claude/skills/rubedo-read-issue/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: rubedo-read-issue
+description: Read a GitHub Issue in the Rubedo project. Use when user wants to view issue details or when starting work on an issue.
+---
+
+You are reading a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Step 1 — Determine issue number
+If the user provided an issue number explicitly, use it.
+
+Otherwise, derive it from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Fetch the issue
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER
+```
+
+Replace `ISSUE_NUMBER` with the number from Step 1.
+
+The output is context for the current session. Do not repeat it back to the user.

--- a/.claude/skills/rubedo-update-issue/SKILL.md
+++ b/.claude/skills/rubedo-update-issue/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rubedo-update-issue
+description: Update the body of an existing GitHub Issue in the Rubedo project. Use when requirements, Acceptance Criteria, or any other issue content needs to change.
+---
+
+You are updating a GitHub Issue for the Rubedo project. Follow these steps precisely.
+
+## Formatting rule
+Write prose as single continuous lines — no manual line breaks within paragraphs
+or list items. GitHub handles word wrapping. Use blank lines to separate paragraphs.
+
+## Step 1 — Determine issue number
+If the user provided an issue number explicitly, use it.
+
+Otherwise, derive it from the current branch name:
+
+```bash
+git branch --show-current
+```
+
+Branch names follow the pattern `{number}-{slug}`, e.g. `20-switch-pr-and-issue-workflow-to-gh-cli` → issue #20.
+Extract the leading number. If no number can be determined, ask the user.
+
+## Step 2 — Fetch current issue content
+Run:
+
+```bash
+gh issue view ISSUE_NUMBER --json title,body --jq '{title: .title, body: .body}'
+```
+
+Load the current title and body into context. Do not repeat them back to the user.
+
+## Step 3 — Collect changes
+Ask the user what should change. Apply the requested changes to the body while
+preserving all unaffected sections.
+
+Once you have enough context, present the complete proposed new body to the user
+for approval.
+
+## Step 4 — Update the issue
+Run:
+
+```bash
+gh issue edit ISSUE_NUMBER --body "NEW_BODY"
+```
+
+Replace `ISSUE_NUMBER` with the number from Step 1 and `NEW_BODY` with the
+approved body from Step 3.
+
+Confirm with the user before running the command.

--- a/docs/conventions/workflow.md
+++ b/docs/conventions/workflow.md
@@ -51,6 +51,12 @@ issues.
 Release conventions are not finalised yet.
 To be defined once ADR-0004 moves beyond Draft.
 
+## Tooling
+
+`gh` (GitHub CLI) is the standard tool for all GitHub operations — creating
+issues, fetching issue details, opening pull requests. No GitHub MCP tools are
+used.
+
 ## Decisions that change these conventions
 
 Changes to this document also go through a PR. Significant changes — anything


### PR DESCRIPTION
Closes #20

## Summary

- Replaced all `mcp__github__*` references in `rubedo-create-issue` and `rubedo-create-pr` skills with `gh` CLI commands with explicit placeholders
- Added `## Tooling` section to `docs/conventions/workflow.md` declaring `gh` as the standard GitHub tool
- Added three new skills: `rubedo-read-issue`, `rubedo-create-commit`, `rubedo-update-issue`
- All changes applied to both `.claude/skills/` and `.agents/skills/` locations

## Scope

Included: skill files updated, new skills added, `workflow.md` updated, formatting rule (no manual line wrapping) applied across all skills.

Not included: no changes to repository settings, CI/CD, or other tooling.

## Verification

- `grep -r "mcp__github"` across the repo returns no matches ✓
- `gh issue view`, `gh issue edit`, `gh pr create` commands exercised end-to-end in this session ✓