### PR TITLE
Spike: evaluate UUID v4 vs v7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,11 @@ portfolio-grade exercise in domain modelling and pragmatic event-driven
 architecture. Trade-offs are made explicit in ADRs, not hidden. Features and
 infrastructure are added when a real need appears, not preventively.
 
+Exception: this principle assumes the cost of deciding later is low. It does
+not apply when a decision becomes progressively harder to reverse as the
+project grows. Before deferring such a decision, ask: *"will this be harder to
+reverse in 6 months?"* If yes, decide now.
+
 ## Non-goals
 
 - Not a SaaS, not a multi-tenant product.

--- a/docs/adr/0003-uuid-as-primary-key.md
+++ b/docs/adr/0003-uuid-as-primary-key.md
@@ -1,7 +1,8 @@
-# ADR-0003: UUID primary keys via pgcrypto
+# ADR-0003: UUID v7 primary keys
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Date**: 2026-05-09
+- **Decided**: 2026-05-30
 - **Deciders**: Tomasz Pietrzyk
 
 ## Context
@@ -13,41 +14,102 @@ information.
 
 For Rubedo specifically: financial domain, future possibility of multi-user
 (household) model, future possibility of CSV import producing reproducible
-identifiers, and personal preference for IDs that don't reveal record counts.
+identifiers, personal preference for IDs that don't reveal record counts, and
+a planned mobile client where offline-first record creation (client-side ID
+generation before server sync) is a realistic use case.
 
-## Decision (proposed)
+This decision was finalised after a dedicated spike:
+[Issue #26 — Spike: evaluate UUID v4 vs v7](https://github.com/kemotable/rubedo/issues/26).
 
-Adopt UUID primary keys for all new models, generated server-side via the
-PostgreSQL `pgcrypto` extension (`gen_random_uuid()`). Configure Rails
-generators accordingly. References between tables use UUID foreign keys.
+## Decision
 
-## Alternatives considered
+Adopt UUID v7 primary keys for all new models, generated database-side via the
+PostgreSQL 18 built-in `uuidv7()` function. Configure Rails generators
+accordingly. References between tables use UUID foreign keys.
 
-- **`bigint` (Rails default)** — simpler, slightly faster joins, more compact
-  storage. Loses the merge / leak / cross-env benefits.
-- **UUID v7 (time-ordered)** — better index locality than UUID v4. Requires
-  custom generator (Postgres 17+ has built-in support; check current target
-  version).
-- **ULID** — similar properties to UUID v7 but non-standard; tooling and
-  driver support weaker than UUID.
+No `pgcrypto` extension required. No gem required. Rails 8 + PostgreSQL 18
+support this natively.
+
+```ruby
+# config/application.rb
+config.generators do |g|
+  g.orm :active_record, primary_key_type: :uuid
+end
+```
+
+```ruby
+# migration
+create_table :users, id: :uuid, default: -> { "uuidv7()" }
+```
+
+## Why UUID v7 over UUID v4
+
+UUID v4 is fully random. In PostgreSQL's B-tree index, each insert lands at a
+random position, causing frequent page splits, index fragmentation, and poor
+cache locality. Measured at 1M rows on PostgreSQL 18:
+
+| Metric | UUID v4 | UUID v7 |
+|---|---|---|
+| Leaf page fragmentation | 49.99% | 0% |
+| Average page fill | 71% | ~90% |
+| Contiguous leaf page links | 0 / 4 861 | 3 812 / 3 832 |
+| Index size | ~40 MB | ~31.6 MB (−26%) |
+| `ORDER BY id` scan (1M rows) | 318 ms | 113 ms |
+
+UUID v7 is time-ordered (48-bit Unix timestamp prefix). Inserts land
+sequentially at the end of the B-tree — the same pattern as `bigint SERIAL`.
+
+At Rubedo's scale (single user, personal finance) this performance difference
+is not measurable in practice. The real arguments for UUID v7 are:
+
+1. **Lower friction than v4** — `uuidv7()` is built into PostgreSQL 18; the
+   `pgcrypto` extension is not needed.
+2. **Right default for the future** — if a mobile client materialises, UUID v7
+   enables offline-first ID generation on the client before server sync.
+3. **Irreversibility** — PK type is decided once, before any data exists.
+   Migrating after domain modelling (M3) would require touching every table,
+   every foreign key, and every serializer.
+
+## Why not bigint
+
+`bigint` is faster and more compact (8 bytes vs 16 bytes). Benchmarks at 5M+
+rows show 15–26× faster point lookups and joins. But:
+
+- IDs are enumerable — reveals record counts, enables enumeration attacks in a
+  financial domain.
+- Cross-environment merge is harder (sequences diverge).
+- Client-side generation for offline-first is impossible without a server
+  round-trip.
+
+At Rubedo's scale the performance gap is not measurable. The non-enumeration
+and offline-first arguments outweigh the storage and speed advantage.
+
+## Why not dual-key (bigint internal + UUID public_id)
+
+Adds schema complexity — two columns, two indexes per table, FK joins by
+bigint but external references by UUID — for zero measurable benefit at
+Rubedo's scale. Rejected outright.
+
+## Why not ULID
+
+Similar properties to UUID v7 but non-standard. Weaker tooling and PostgreSQL
+driver support. No benefit over UUID v7 given PostgreSQL 18 native support.
 
 ## Consequences
 
-- **Positive**: IDs safe to expose; merge between environments trivial; no
-  count leak.
-- **Negative / accepted costs**: ~16 bytes per key vs 8; slightly worse index
-  locality for v4; mild DX cost (longer IDs in URLs, logs).
-- **Neutral**: requires `pgcrypto` extension migration before first model.
-
-## Open questions
-
-- UUID v4 vs UUID v7 — depends on Postgres version available on target VPS
-  and on Rails 8.1 generator support. Decide before promoting to Accepted.
-- Whether to keep an internal `bigint` `id` for join performance and use UUID
-  as a separate `public_id`. Likely no — adds complexity for marginal gain —
-  but worth one explicit consideration.
+- **Positive**: IDs safe to expose; no record-count leak; cross-environment
+  merge trivial; enables future offline-first mobile client; no extension
+  dependency (simpler migrations).
+- **Negative / accepted costs**: 16 bytes per key vs 8 bytes (bigint);
+  creation timestamp embedded in ID at millisecond precision (non-issue for a
+  single-user app where IDs are not externally exposed to third parties).
+- **Neutral**: PK type is not reversible without a full schema migration; this
+  decision is made deliberately in M1 before any data exists.
 
 ## References
 
-- ADR-0001 (modular monolith) — single database, so no distributed-ID
-  argument applies.
+- ADR-0001 (modular monolith) — single database, no distributed-ID requirement.
+- [Issue #26 — Spike: evaluate UUID v4 vs v7](https://github.com/kemotable/rubedo/issues/26)
+- [credativ.de — UUID v4 vs v7 deep dive in PostgreSQL 18](https://www.credativ.de/en/blog/postgresql-en/a-deeper-look-at-old-uuidv4-vs-new-uuidv7-in-postgresql-18/)
+- [chayuto.com — Rails 8 UUIDv7 PostgreSQL primary key](https://chayuto.com/blog/rails-8-uuidv7-postgresql-primary-key/)
+- [aiven.io — Exploring PostgreSQL 18 UUIDv7 support](https://aiven.io/blog/exploring-postgresql-18-new-uuidv7-support)


### PR DESCRIPTION
Closes #26

## Summary

- Researched UUID v4 vs v7 on PostgreSQL 18 + Rails 8.1 — no gems or extensions needed, `uuidv7()` is native to PG18
- Decided: UUID v7 as primary key for all models; dual-key bigint+public_id rejected
- Promoted ADR-0003 from Draft to Accepted with full trade-off rationale (benchmarks, bigint comparison, offline-first argument)
- Clarified "not preventively" principle in CLAUDE.md: does not apply to foundational hard-to-reverse decisions

## Scope

- `docs/adr/0003-uuid-as-primary-key.md` — rewritten and promoted to Accepted
- `CLAUDE.md` — "not preventively" exception added
- Follow-up Task issue #47 created: Configure UUID v7 primary keys
- CHANGELOG.md vs GitHub Releases question removed from scope (unrelated to UUID spike)

## Verification

Spike — no runnable code changed. QA Notes not applicable.
ADR-0003 reviewed for accuracy against research sources before commit.