### PR TITLE
Configure UUID v7 primary keys

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,7 @@ module Rubedo
 
     config.generators do |g|
       g.template_engine :haml
+      g.orm :active_record, primary_key_type: :uuid
     end
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.1].define(version: 0) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_catalog.plpgsql"
+end

--- a/lib/templates/active_record/migration/create_table_migration.rb.tt
+++ b/lib/templates/active_record/migration/create_table_migration.rb.tt
@@ -1,0 +1,40 @@
+<% template_rails = [8, 1]
+   current_rails  = [Rails::VERSION::MAJOR, Rails::VERSION::MINOR]
+   if current_rails != template_rails
+     warn "\n[WARNING] lib/templates/active_record/migration/create_table_migration.rb.tt" \
+          " was copied from Rails #{template_rails.join(".")}." \
+          " You are running Rails #{Rails::VERSION::STRING}." \
+          " Compare with upstream and merge any changes:\n" \
+          " gems/activerecord-#{Rails::VERSION::STRING}/lib/rails/generators" \
+          "/active_record/migration/templates/create_table_migration.rb.tt\n"
+   end
+%>
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
+  def change
+    create_table :<%= table_name %><%= primary_key_type %><% if options[:primary_key_type].to_s == "uuid" %>, default: -> { "uuidv7()" }<% end %> do |t|
+<% attributes.each do |attribute| -%>
+<% if attribute.password_digest? -%>
+      t.string :password_digest<%= attribute.inject_options %>
+<% elsif attribute.token? -%>
+      t.string :<%= attribute.name %><%= attribute.inject_options %>
+<% elsif attribute.reference? -%>
+      t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %><%= foreign_key_type %>
+<% elsif !attribute.virtual? -%>
+      t.<%= attribute.type %> :<%= attribute.name %><%= attribute.inject_options %>
+<% end -%>
+<% end -%>
+<% unless attributes.empty? -%>
+
+<% end -%>
+<% if options[:timestamps] -%>
+      t.timestamps
+<% end -%>
+    end
+<% attributes.select(&:token?).each do |attribute| -%>
+    add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>, unique: true
+<% end -%>
+<% attributes_with_index.each do |attribute| -%>
+    add_index :<%= table_name %>, :<%= attribute.index_name %><%= attribute.inject_index_options %>
+<% end -%>
+  end
+end


### PR DESCRIPTION
Closes #47

## Summary

- Configured Rails generators to use `:uuid` as the primary key type for all new models
- Added a custom migration template that injects `default: -> { "uuidv7()" }` so PostgreSQL 18's native `uuidv7()` function generates time-ordered UUIDs at the database level
- Template includes a version guard that prints a warning at generation time if Rails is upgraded beyond 8.1, prompting comparison with the upstream template

## Scope

- Implements ADR-0003
- Only `create_table` migrations are affected — foreign key columns are handled correctly by Rails' existing `foreign_key_type` helper without changes
- `db/schema.rb` added to version control (initial empty schema, no tables yet)
- `bin/` script updates from Rails 8.1.3 left out — unrelated to this issue

## Verification

- Generated throwaway model `Foo` — migration produced `id: :uuid, default: -> { "uuidv7()" }` ✓
- `rails db:migrate` ran without errors ✓
- Created a record with UUID v7 primary key: `019e7f81-8b75-7f75-939d-9de1d9254381` (version nibble `7`, timestamp prefix matches current date) ✓
- Rolled back migration and destroyed throwaway model before merging ✓