### PR TITLE
Document tooling conventions and PostgreSQL

### DIFF
--- a/docs/adr/0001-modular-monolith.md
+++ b/docs/adr/0001-modular-monolith.md
@@ -14,7 +14,7 @@ Automation) with low operational overhead.
 ## Decision
 
 Build Rubedo as a **modular monolith**: one Rails application, one deployable
-unit, one database. Internal modularity is enforced through namespacing,
+unit, one PostgreSQL database. Internal modularity is enforced through namespacing,
 explicit module boundaries, and conscious dependency direction — not through
 service or process separation.
 
@@ -40,3 +40,4 @@ service or process separation.
 ## References
 
 - `CLAUDE.md` — project character.
+- ADR-0003 — UUID v7 primary keys; defines PostgreSQL 18 as the required engine version.

--- a/docs/conventions/code.md
+++ b/docs/conventions/code.md
@@ -12,6 +12,18 @@ Conventions derived from architectural decisions are added here only after
 the relevant ADR reaches `Status: Accepted`. While an ADR is in `Draft`,
 its rules are not yet binding and do not appear in this file.
 
+## Templates
+
+HAML is the template language for all views. ERB is not used.
+
+## Linting
+
+**Ruby** — RuboCop is the linter. `.rubocop.yml` is the authoritative config; run `rubocop` before every merge. Enforcement via CI lands in M2.
+
+**HAML** — haml_lint is the linter. Run `haml_lint app/views/` before every merge. Enforcement via CI lands in M2.
+
+**JavaScript** — ESLint is the linter (`eslint.config.js`); Prettier is the formatter (`.prettierrc`). Run `yarn lint:js` to check and `yarn format:js` to format before every merge.
+
 ## Testing
 
 To be added when the test framework lands (milestone M2).


### PR DESCRIPTION
Closes #27

## Summary

- Added `## Templates` section to `code.md`: HAML is the template language, ERB is not used.
- Added `## Linting` section to `code.md`: RuboCop, haml_lint, ESLint, Prettier — each with reference to its authoritative config file and run command.
- Updated ADR-0001: named PostgreSQL explicitly in the Decision; added reference to ADR-0003 as the source of the PostgreSQL 18 version requirement.
- Dropped the pgcrypto note from the AC — ADR-0003 explicitly states pgcrypto is not required (PostgreSQL 18 native `uuidv7()`).

## Scope

- Docs only; no code changes.
- JS linters (ESLint, Prettier) and haml_lint added to scope — omitted from the original issue, present in the repo.
- Packwerk ADR deferred to M3 — tracked as Issue #50.

## Verification

- `code.md` contains `## Templates` and `## Linting` sections — unambiguous entries for HAML, RuboCop, haml_lint, ESLint, Prettier.
- ADR-0001 Decision names PostgreSQL explicitly; References section links to ADR-0003.
- No pgcrypto mention anywhere.