### PR TITLE
Switch database.yml to ENV defaults

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,20 +6,20 @@ default: &default
 development:
   <<: *default
   database: rubedo_development
-  username: rubedo
-  password: <%= Rails.application.credentials.dig(:db, :password) %>
-  host: localhost
+  username: <%= ENV.fetch("DB_USERNAME", "rubedo") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "rubedo") %>
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
 
 test:
   <<: *default
   database: rubedo_test
-  username: rubedo
-  password: <%= Rails.application.credentials.dig(:db, :password) %>
-  host: localhost
+  username: <%= ENV.fetch("DB_USERNAME", "rubedo") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "rubedo") %>
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
 
 production:
   <<: *default
   database: rubedo_production
-  username: rubedo
+  username: <%= Rails.application.credentials.dig(:db, :username) %>
   password: <%= Rails.application.credentials.dig(:db, :password) %>
-  host: localhost
+  host: <%= Rails.application.credentials.dig(:db, :host) %>


### PR DESCRIPTION
Closes #52

## Summary

- Dev and test environments now use `ENV.fetch` with defaults matching `docker-compose.yml` (`DB_USERNAME`, `DB_PASSWORD`, `DB_HOST` all default to `"rubedo"`/`"rubedo"`/`"localhost"`).
- Production now reads `username` and `host` from Rails credentials (previously hardcoded); `password` already used credentials.
- A fresh clone can run `bin/rails db:setup` without `config/credentials/development.key`.

## Scope

- Only `config/database.yml` changed.
- No `.env.example` added — defaults are explicit in the code, project is single-developer.
- Production credentials (`db.username`, `db.host`) are not populated here — that is a deployment-time concern. **Before first production deploy**, credentials must be updated to include these keys.

## Verification

- `bin/rails db:setup` runs successfully on an existing dev environment (confirmed).
- Fresh clone without `development.key` will succeed because dev/test no longer read from credentials (verified by logic — credentials call removed).